### PR TITLE
SourceClear fixes for vulnerable libraries.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,1828 @@
+{
+  "name": "example-javascript",
+  "version": "0.0.1",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "@types/geojson": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-1.0.6.tgz",
+      "integrity": "sha512-Xqg/lIZMrUd0VRmSRbCAewtwGZiAk3mEUDvV4op1tGl+LvyPcb/MIOSxTl9z+9+J+R4/vpjiCAT4xeKzH9ji1w=="
+    },
+    "accepts": {
+      "version": "1.2.13",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.2.13.tgz",
+      "integrity": "sha1-5fHzkoxtlf2WVYw27D2dDeSm7Oo=",
+      "requires": {
+        "mime-types": "2.1.18",
+        "negotiator": "0.5.3"
+      }
+    },
+    "after": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/after/-/after-0.8.1.tgz",
+      "integrity": "sha1-q11PuIP1loFtNRX495HAr0ht1ic="
+    },
+    "amdefine": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz",
+      "integrity": "sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU="
+    },
+    "angular": {
+      "version": "1.3.19",
+      "resolved": "https://registry.npmjs.org/angular/-/angular-1.3.19.tgz",
+      "integrity": "sha1-xG6rdD06jrxyiF3ujn3jIZMsXJ0="
+    },
+    "array-flatten": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
+      "integrity": "sha1-ml9pkFGx5wczKPKgCJaLZOopVdI="
+    },
+    "arraybuffer.slice": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/arraybuffer.slice/-/arraybuffer.slice-0.0.6.tgz",
+      "integrity": "sha1-8zshWfBTKj8xB6JywMz70a0peco="
+    },
+    "backo2": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/backo2/-/backo2-1.0.2.tgz",
+      "integrity": "sha1-MasayLEpNjRj41s+u2n038+6eUc="
+    },
+    "balanced-match": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
+    },
+    "base64-arraybuffer": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/base64-arraybuffer/-/base64-arraybuffer-0.1.2.tgz",
+      "integrity": "sha1-R030qfLaJOBd8xWMOx2zw81GoVQ="
+    },
+    "base64id": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/base64id/-/base64id-0.1.0.tgz",
+      "integrity": "sha1-As4P3u4M709ACA4ec+g08LG/zj8="
+    },
+    "benchmark": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/benchmark/-/benchmark-1.0.0.tgz",
+      "integrity": "sha1-Lx4vpMNZ8REiqhgwgiGOlX45DHM="
+    },
+    "better-assert": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/better-assert/-/better-assert-1.0.2.tgz",
+      "integrity": "sha1-QIZrnhueC1W0gYlDEeaPr/rrxSI=",
+      "requires": {
+        "callsite": "1.0.0"
+      }
+    },
+    "blob": {
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/blob/-/blob-0.0.4.tgz",
+      "integrity": "sha1-vPEwUspURj8w+fx+lbmkdjCpSSE="
+    },
+    "bluebird": {
+      "version": "3.5.1",
+      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.1.tgz",
+      "integrity": "sha512-MKiLiV+I1AA596t9w1sQJ8jkiSr5+ZKi0WKrYGUn6d1Fx+Ij4tIj+m2WMQSGczs5jZVxV339chE8iwk6F64wjA=="
+    },
+    "boom": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/boom/-/boom-0.3.0.tgz",
+      "integrity": "sha1-H/7a+JPUZ5PcqONc80fbyTIQ9eg=",
+      "requires": {
+        "hoek": "0.4.5"
+      }
+    },
+    "brace-expansion": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "requires": {
+        "balanced-match": "1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "buffer-crc32": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.3.tgz",
+      "integrity": "sha1-u1RRnpXRB8vSQA520MqxRnM22SE="
+    },
+    "callsite": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/callsite/-/callsite-1.0.0.tgz",
+      "integrity": "sha1-KAOY5dZkvXQDi28JBRU+borxvCA="
+    },
+    "camel-case": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/camel-case/-/camel-case-3.0.0.tgz",
+      "integrity": "sha1-yjw2iKTpzzpM2nd9xNy8cTJJz3M=",
+      "requires": {
+        "no-case": "2.3.2",
+        "upper-case": "1.1.3"
+      }
+    },
+    "checkup": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/checkup/-/checkup-1.3.0.tgz",
+      "integrity": "sha1-04ACdv6l0PJH/8lRvnjIsC+ODXY="
+    },
+    "clean-css": {
+      "version": "3.4.28",
+      "resolved": "https://registry.npmjs.org/clean-css/-/clean-css-3.4.28.tgz",
+      "integrity": "sha1-vxlF6C/ICPVWlebd6uwBQA79A/8=",
+      "requires": {
+        "commander": "2.8.1",
+        "source-map": "0.4.4"
+      }
+    },
+    "commander": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.8.1.tgz",
+      "integrity": "sha1-Br42f+v9oMMwqh4qBy09yXYkJdQ=",
+      "requires": {
+        "graceful-readlink": "1.0.1"
+      }
+    },
+    "component-bind": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/component-bind/-/component-bind-1.0.0.tgz",
+      "integrity": "sha1-AMYIq33Nk4l8AAllGx06jh5zu9E="
+    },
+    "component-emitter": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.1.2.tgz",
+      "integrity": "sha1-KWWU8nU9qmOZbSrwjRWpURbJrsM="
+    },
+    "component-inherit": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/component-inherit/-/component-inherit-0.0.3.tgz",
+      "integrity": "sha1-ZF/ErfWLcrZJ1crmUTVhnbJv8UM="
+    },
+    "concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+    },
+    "console-io": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/console-io/-/console-io-2.7.0.tgz",
+      "integrity": "sha1-KbsJvrB/vq/w1TEhi3hTDbkgGzs=",
+      "requires": {
+        "debug": "2.2.0",
+        "express": "4.13.4",
+        "join-io": "1.4.6",
+        "mollify": "1.0.8",
+        "rendy": "1.1.1",
+        "socket.io": "1.4.8",
+        "spawnify": "2.3.4",
+        "tildify": "1.1.2"
+      },
+      "dependencies": {
+        "cookie-signature": {
+          "version": "1.0.6",
+          "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
+          "integrity": "sha1-4wOogrNCzD7oylE6eZmXNNqzriw="
+        },
+        "express": {
+          "version": "4.13.4",
+          "resolved": "https://registry.npmjs.org/express/-/express-4.13.4.tgz",
+          "integrity": "sha1-PAt288d1kMg0VzkGHsC9O6Bn7CQ=",
+          "requires": {
+            "accepts": "1.2.13",
+            "array-flatten": "1.1.1",
+            "content-disposition": "0.5.1",
+            "content-type": "1.0.4",
+            "cookie": "0.1.5",
+            "cookie-signature": "1.0.6",
+            "debug": "2.2.0",
+            "depd": "1.1.2",
+            "escape-html": "1.0.3",
+            "etag": "1.7.0",
+            "finalhandler": "0.4.1",
+            "fresh": "0.3.0",
+            "merge-descriptors": "1.0.1",
+            "methods": "1.1.2",
+            "on-finished": "2.3.0",
+            "parseurl": "1.3.2",
+            "path-to-regexp": "0.1.7",
+            "proxy-addr": "1.0.10",
+            "qs": "4.0.0",
+            "range-parser": "1.0.3",
+            "send": "0.13.1",
+            "serve-static": "1.10.3",
+            "type-is": "1.6.16",
+            "utils-merge": "1.0.0",
+            "vary": "1.0.1"
+          }
+        }
+      }
+    },
+    "content-disposition": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.1.tgz",
+      "integrity": "sha1-h0dsamfI2qh+Muh2Ft+IO6f7Bxs="
+    },
+    "content-type": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.4.tgz",
+      "integrity": "sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA=="
+    },
+    "cookie": {
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.1.5.tgz",
+      "integrity": "sha1-armUiksa4hlSzSWIUwpHItQETXw="
+    },
+    "cookie-signature": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.4.tgz",
+      "integrity": "sha1-Dt0iKG46ERuaKnDbNj6SXoZ/aso="
+    },
+    "css-b64-images": {
+      "version": "0.2.5",
+      "resolved": "https://registry.npmjs.org/css-b64-images/-/css-b64-images-0.2.5.tgz",
+      "integrity": "sha1-QgBdgyBLK0pdk7axpWRBM7WSegI="
+    },
+    "currify": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/currify/-/currify-2.0.6.tgz",
+      "integrity": "sha512-F0lbcoBkA2FMcejFeHJkDEhQ1AvVkTpkn9PMzJch+7mHy5WdteZ9t+nhT6cOdga4uRay3rjvprgp8tUkixFy8w=="
+    },
+    "debug": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
+      "integrity": "sha1-+HBX6ZWxofauaklgZkE3vFbwOdo=",
+      "requires": {
+        "ms": "0.7.1"
+      }
+    },
+    "depd": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
+      "integrity": "sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak="
+    },
+    "destroy": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz",
+      "integrity": "sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA="
+    },
+    "dottie": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/dottie/-/dottie-1.1.1.tgz",
+      "integrity": "sha1-RcKj9IvWUo7u0memmoSOqspvqmo="
+    },
+    "ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0="
+    },
+    "engine.io": {
+      "version": "1.6.11",
+      "resolved": "https://registry.npmjs.org/engine.io/-/engine.io-1.6.11.tgz",
+      "integrity": "sha1-JTOpemWHbED/z5U5e375tJXEI/4=",
+      "requires": {
+        "accepts": "1.1.4",
+        "base64id": "0.1.0",
+        "debug": "2.2.0",
+        "engine.io-parser": "1.2.4",
+        "ws": "1.1.0"
+      },
+      "dependencies": {
+        "accepts": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.1.4.tgz",
+          "integrity": "sha1-1xyW99QdD+2iw4zRToonwEFY30o=",
+          "requires": {
+            "mime-types": "2.0.14",
+            "negotiator": "0.4.9"
+          }
+        },
+        "mime-db": {
+          "version": "1.12.0",
+          "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.12.0.tgz",
+          "integrity": "sha1-PQxjGA9FjrENMlqqN9fFiuMS6dc="
+        },
+        "mime-types": {
+          "version": "2.0.14",
+          "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.0.14.tgz",
+          "integrity": "sha1-MQ4VnbI+B3+Lsit0jav6SVcUCqY=",
+          "requires": {
+            "mime-db": "1.12.0"
+          }
+        },
+        "negotiator": {
+          "version": "0.4.9",
+          "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.4.9.tgz",
+          "integrity": "sha1-kuRrbbU8fkIe1koryU8IvnYw3z8="
+        }
+      }
+    },
+    "engine.io-client": {
+      "version": "1.6.11",
+      "resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-1.6.11.tgz",
+      "integrity": "sha1-fSUNj6HCGBGezeUTkEWKV9UXE3Y=",
+      "requires": {
+        "component-emitter": "1.1.2",
+        "component-inherit": "0.0.3",
+        "debug": "2.2.0",
+        "engine.io-parser": "1.2.4",
+        "has-cors": "1.1.0",
+        "indexof": "0.0.1",
+        "parsejson": "0.0.1",
+        "parseqs": "0.0.2",
+        "parseuri": "0.0.4",
+        "ws": "1.0.1",
+        "xmlhttprequest-ssl": "1.5.1",
+        "yeast": "0.1.2"
+      },
+      "dependencies": {
+        "ws": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/ws/-/ws-1.0.1.tgz",
+          "integrity": "sha1-fQsqLljN3YGQOcKcneZQReGzEOk=",
+          "requires": {
+            "options": "0.0.6",
+            "ultron": "1.0.2"
+          }
+        }
+      }
+    },
+    "engine.io-parser": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-1.2.4.tgz",
+      "integrity": "sha1-4Il7C/FOeS1M0qWVBVORnFaUjEI=",
+      "requires": {
+        "after": "0.8.1",
+        "arraybuffer.slice": "0.0.6",
+        "base64-arraybuffer": "0.1.2",
+        "blob": "0.0.4",
+        "has-binary": "0.1.6",
+        "utf8": "2.1.0"
+      },
+      "dependencies": {
+        "has-binary": {
+          "version": "0.1.6",
+          "resolved": "https://registry.npmjs.org/has-binary/-/has-binary-0.1.6.tgz",
+          "integrity": "sha1-JTJvOc+k9hath4eJTjryz7x7bhA=",
+          "requires": {
+            "isarray": "0.0.1"
+          }
+        }
+      }
+    },
+    "escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg="
+    },
+    "etag": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.7.0.tgz",
+      "integrity": "sha1-A9MLX2fdbmMtKUXTDWZScxo01dg="
+    },
+    "execon": {
+      "version": "1.2.9",
+      "resolved": "https://registry.npmjs.org/execon/-/execon-1.2.9.tgz",
+      "integrity": "sha1-bbETM9zIJPHxPnMX/tDZSi8mSR8="
+    },
+    "express": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.5.0.tgz",
+      "integrity": "sha1-ZMaLnkH2YznJWkYvN/lP9DZyS9c=",
+      "requires": {
+        "accepts": "1.0.7",
+        "buffer-crc32": "0.2.3",
+        "cookie": "0.1.2",
+        "cookie-signature": "1.0.4",
+        "debug": "1.0.2",
+        "depd": "0.3.0",
+        "escape-html": "1.0.1",
+        "finalhandler": "0.0.2",
+        "fresh": "0.2.2",
+        "media-typer": "0.2.0",
+        "merge-descriptors": "0.0.2",
+        "methods": "1.0.1",
+        "parseurl": "1.0.1",
+        "path-to-regexp": "0.1.2",
+        "proxy-addr": "1.0.1",
+        "qs": "0.6.6",
+        "range-parser": "1.0.0",
+        "send": "0.5.0",
+        "serve-static": "1.3.2",
+        "type-is": "1.3.2",
+        "utils-merge": "1.0.0",
+        "vary": "0.1.0"
+      },
+      "dependencies": {
+        "accepts": {
+          "version": "1.0.7",
+          "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.0.7.tgz",
+          "integrity": "sha1-W1AftPBwQwmWTM2wSBclQSCNqxo=",
+          "requires": {
+            "mime-types": "1.0.2",
+            "negotiator": "0.4.7"
+          }
+        },
+        "cookie": {
+          "version": "0.1.2",
+          "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.1.2.tgz",
+          "integrity": "sha1-cv7D0k5Io0Mgc9kMEmQgBQYQBLE="
+        },
+        "debug": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-1.0.2.tgz",
+          "integrity": "sha1-OElZHBDM5khHbDx8Li40FttZY8Q=",
+          "requires": {
+            "ms": "0.6.2"
+          }
+        },
+        "depd": {
+          "version": "0.3.0",
+          "resolved": "https://registry.npmjs.org/depd/-/depd-0.3.0.tgz",
+          "integrity": "sha1-Ecm8KOQlMl+9iziUC+/2n6UyaIM="
+        },
+        "escape-html": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.1.tgz",
+          "integrity": "sha1-GBoobq05ejmpKFfPsdQwUuNWv/A="
+        },
+        "finalhandler": {
+          "version": "0.0.2",
+          "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-0.0.2.tgz",
+          "integrity": "sha1-BgPYde6H1WeiZmkoFcyK1E/M7to=",
+          "requires": {
+            "debug": "1.0.2",
+            "escape-html": "1.0.1"
+          }
+        },
+        "fresh": {
+          "version": "0.2.2",
+          "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.2.2.tgz",
+          "integrity": "sha1-lzHc9WeMf660T7kDxPct9VGH+nc="
+        },
+        "ipaddr.js": {
+          "version": "0.1.2",
+          "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-0.1.2.tgz",
+          "integrity": "sha1-ah/T2FT1ACllw017vNm0qNSwRn4="
+        },
+        "media-typer": {
+          "version": "0.2.0",
+          "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.2.0.tgz",
+          "integrity": "sha1-2KBlITrf6qLnYyGitt2jb/YzWYQ="
+        },
+        "merge-descriptors": {
+          "version": "0.0.2",
+          "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-0.0.2.tgz",
+          "integrity": "sha1-w2pSp4FDdRPFcnXzndnTF1FKyMc="
+        },
+        "methods": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/methods/-/methods-1.0.1.tgz",
+          "integrity": "sha1-dbyRlD3/19oDfPPusO1zoAN80Us="
+        },
+        "mime": {
+          "version": "1.2.11",
+          "resolved": "https://registry.npmjs.org/mime/-/mime-1.2.11.tgz",
+          "integrity": "sha1-WCA+7Ybjpe8XrtK32evUfwpg3RA="
+        },
+        "mime-types": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-1.0.2.tgz",
+          "integrity": "sha1-mVrhOSq4r/y/yyZB3QVOlDwNXc4="
+        },
+        "ms": {
+          "version": "0.6.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-0.6.2.tgz",
+          "integrity": "sha1-2JwhJMb9wTU9Zai3e/GqxLGTcIw="
+        },
+        "negotiator": {
+          "version": "0.4.7",
+          "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.4.7.tgz",
+          "integrity": "sha1-pBYPcXfsgGc4Yx0NMFIyXaQqvcg="
+        },
+        "parseurl": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.0.1.tgz",
+          "integrity": "sha1-Llfc5u/dN8NRhwEDCUTCK/OIt7Q="
+        },
+        "path-to-regexp": {
+          "version": "0.1.2",
+          "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.2.tgz",
+          "integrity": "sha1-mysVH5zDAYye6lDKlXKeBXgXErQ="
+        },
+        "proxy-addr": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-1.0.1.tgz",
+          "integrity": "sha1-x8Vm1etOP61n7rnHfFVYzMObiKg=",
+          "requires": {
+            "ipaddr.js": "0.1.2"
+          }
+        },
+        "qs": {
+          "version": "0.6.6",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-0.6.6.tgz",
+          "integrity": "sha1-bgFQmP9RlouKPIGQAdXyyJvEsQc="
+        },
+        "range-parser": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.0.0.tgz",
+          "integrity": "sha1-pLJkz+C+XONqvjdlrJwqJIdG28A="
+        },
+        "send": {
+          "version": "0.5.0",
+          "resolved": "https://registry.npmjs.org/send/-/send-0.5.0.tgz",
+          "integrity": "sha1-/A9+L5Limuv9ihst60o5TnpTGmg=",
+          "requires": {
+            "debug": "1.0.2",
+            "escape-html": "1.0.1",
+            "finished": "1.2.2",
+            "fresh": "0.2.2",
+            "mime": "1.2.11",
+            "ms": "0.6.2",
+            "range-parser": "1.0.0"
+          }
+        },
+        "serve-static": {
+          "version": "1.3.2",
+          "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.3.2.tgz",
+          "integrity": "sha1-2QSmy/VfURx4E49vRe5uadnRBco=",
+          "requires": {
+            "escape-html": "1.0.1",
+            "parseurl": "1.1.3",
+            "send": "0.6.0"
+          },
+          "dependencies": {
+            "debug": {
+              "version": "1.0.3",
+              "resolved": "https://registry.npmjs.org/debug/-/debug-1.0.3.tgz",
+              "integrity": "sha1-/IxrLWACgEtAgcAgjg9kYLofo+Q=",
+              "requires": {
+                "ms": "0.6.2"
+              }
+            },
+            "parseurl": {
+              "version": "1.1.3",
+              "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.1.3.tgz",
+              "integrity": "sha1-HwBXOKxxtBe8LQhFy9+iqLY+pjk="
+            },
+            "send": {
+              "version": "0.6.0",
+              "resolved": "https://registry.npmjs.org/send/-/send-0.6.0.tgz",
+              "integrity": "sha1-pZ2pJl23w1FB4Qec8fNo7g1Zs6s=",
+              "requires": {
+                "debug": "1.0.3",
+                "depd": "0.3.0",
+                "escape-html": "1.0.1",
+                "finished": "1.2.2",
+                "fresh": "0.2.2",
+                "mime": "1.2.11",
+                "ms": "0.6.2",
+                "range-parser": "1.0.0"
+              }
+            }
+          }
+        },
+        "type-is": {
+          "version": "1.3.2",
+          "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.3.2.tgz",
+          "integrity": "sha1-TypdxYd1yhYwJQr8cYb4s2MJ0bs=",
+          "requires": {
+            "media-typer": "0.2.0",
+            "mime-types": "1.0.2"
+          }
+        },
+        "vary": {
+          "version": "0.1.0",
+          "resolved": "https://registry.npmjs.org/vary/-/vary-0.1.0.tgz",
+          "integrity": "sha1-3wlFiZ6TwMxb0YzIMh2dIedPYXY="
+        }
+      }
+    },
+    "extendy": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/extendy/-/extendy-1.0.1.tgz",
+      "integrity": "sha1-2C6YpnWCLoIhouRr0+hyo0V+nuY="
+    },
+    "files-io": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/files-io/-/files-io-1.2.8.tgz",
+      "integrity": "sha1-1w2kIfO00MSw8P58dhXyQm/EmdE=",
+      "requires": {
+        "extendy": "1.0.1",
+        "itype": "2.0.3",
+        "pipe-io": "2.0.5"
+      }
+    },
+    "finalhandler": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-0.4.1.tgz",
+      "integrity": "sha1-haF8bFmpRxfSYtYSMNSw6+PUoU0=",
+      "requires": {
+        "debug": "2.2.0",
+        "escape-html": "1.0.3",
+        "on-finished": "2.3.0",
+        "unpipe": "1.0.0"
+      }
+    },
+    "finished": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/finished/-/finished-1.2.2.tgz",
+      "integrity": "sha1-QWCOr639ZWg7RqEiC8Sx7D2u3Ng=",
+      "requires": {
+        "ee-first": "1.0.3"
+      },
+      "dependencies": {
+        "ee-first": {
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.0.3.tgz",
+          "integrity": "sha1-bJjECJq+y1p7hcGsRJqmA9Oz2r4="
+        }
+      }
+    },
+    "forwarded": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.1.2.tgz",
+      "integrity": "sha1-mMI9qxF1ZXuMBXPozszZGw/xjIQ="
+    },
+    "fresh": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.3.0.tgz",
+      "integrity": "sha1-ZR+DjiJCTnVm3hYdg1jKoZn4PU8="
+    },
+    "fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
+    },
+    "generic-pool": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/generic-pool/-/generic-pool-2.4.2.tgz",
+      "integrity": "sha1-iGvFvwvrfblugby7oHiBjeWmJoM="
+    },
+    "glob": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+      "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+      "requires": {
+        "fs.realpath": "1.0.0",
+        "inflight": "1.0.6",
+        "inherits": "2.0.3",
+        "minimatch": "3.0.4",
+        "once": "1.4.0",
+        "path-is-absolute": "1.0.1"
+      }
+    },
+    "graceful-readlink": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz",
+      "integrity": "sha1-TK+tdrxi8C+gObL5Tpo906ORpyU="
+    },
+    "hapi": {
+      "version": "11.1.4",
+      "resolved": "https://registry.npmjs.org/hapi/-/hapi-11.1.4.tgz",
+      "integrity": "sha1-qAWI0XWh2UiazaD90T31oHZvVc4=",
+      "requires": {
+        "accept": "2.0.0",
+        "ammo": "2.0.0",
+        "boom": "3.0.0",
+        "call": "3.0.0",
+        "catbox": "7.0.0",
+        "catbox-memory": "2.0.1",
+        "cryptiles": "3.0.0",
+        "heavy": "4.0.0",
+        "hoek": "3.0.0",
+        "iron": "3.0.1",
+        "items": "2.0.0",
+        "joi": "7.0.0",
+        "kilt": "2.0.0",
+        "mimos": "3.0.0",
+        "peekaboo": "2.0.0",
+        "qs": "6.0.0",
+        "shot": "2.0.1",
+        "statehood": "3.0.0",
+        "subtext": "3.0.1",
+        "topo": "2.0.0"
+      },
+      "dependencies": {
+        "accept": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/accept/-/accept-2.0.0.tgz",
+          "integrity": "sha1-IZ/zxonoytxxmV5L2dtwRaOMNFk=",
+          "requires": {
+            "boom": "3.0.0",
+            "hoek": "3.0.0"
+          }
+        },
+        "ammo": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ammo/-/ammo-2.0.0.tgz",
+          "integrity": "sha1-FNvfwfti19gmAgbTfkghkmXSS+g=",
+          "requires": {
+            "boom": "3.0.0",
+            "hoek": "3.0.0"
+          }
+        },
+        "boom": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/boom/-/boom-3.0.0.tgz",
+          "integrity": "sha1-z/hYy9AMZcEeanS0qdyQueO5BsQ=",
+          "requires": {
+            "hoek": "3.0.0"
+          }
+        },
+        "call": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/call/-/call-3.0.0.tgz",
+          "integrity": "sha1-6VTpAzInH3qxJgtN4BjWjq+z8BE=",
+          "requires": {
+            "boom": "3.0.0",
+            "hoek": "3.0.0"
+          }
+        },
+        "catbox": {
+          "version": "7.0.0",
+          "resolved": "https://registry.npmjs.org/catbox/-/catbox-7.0.0.tgz",
+          "integrity": "sha1-PUACQlj1az+YUemblXY+BrxjpEI=",
+          "requires": {
+            "boom": "3.0.0",
+            "hoek": "3.0.0",
+            "joi": "7.0.0"
+          }
+        },
+        "catbox-memory": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/catbox-memory/-/catbox-memory-2.0.1.tgz",
+          "integrity": "sha1-vfxec2RI/hbA/5FCfU2xGsNNk5Y=",
+          "requires": {
+            "hoek": "3.0.0"
+          }
+        },
+        "cryptiles": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-3.0.0.tgz",
+          "integrity": "sha1-4Uj7j2ZqhxKEPd9lwZZ2nR44eQw=",
+          "requires": {
+            "boom": "3.0.0"
+          }
+        },
+        "heavy": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/heavy/-/heavy-4.0.0.tgz",
+          "integrity": "sha1-ffqckK80PxaAaoxIootJmiPexHE=",
+          "requires": {
+            "boom": "3.0.0",
+            "hoek": "3.0.0",
+            "joi": "7.0.0"
+          }
+        },
+        "hoek": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/hoek/-/hoek-3.0.0.tgz",
+          "integrity": "sha1-UsDfKcp0G05by7C1n1CfNHYjrI0="
+        },
+        "iron": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/iron/-/iron-3.0.1.tgz",
+          "integrity": "sha1-PdOxAKch0VubewM6DPTB4yZgPNM=",
+          "requires": {
+            "boom": "3.0.0",
+            "cryptiles": "3.0.0",
+            "hoek": "3.0.0"
+          }
+        },
+        "items": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/items/-/items-2.0.0.tgz",
+          "integrity": "sha1-0Uqxfgyce47mk3dT07mlbgjUrXo="
+        },
+        "joi": {
+          "version": "7.0.0",
+          "resolved": "https://registry.npmjs.org/joi/-/joi-7.0.0.tgz",
+          "integrity": "sha1-fwpeVsCBiqvXpYNmp5GjgYwLY98=",
+          "requires": {
+            "hoek": "3.0.0",
+            "isemail": "2.0.0",
+            "moment": "2.10.6",
+            "topo": "2.0.0"
+          },
+          "dependencies": {
+            "isemail": {
+              "version": "2.0.0",
+              "resolved": "https://registry.npmjs.org/isemail/-/isemail-2.0.0.tgz",
+              "integrity": "sha1-rlk4hsFzJ+j1z3x9VAA6scpWbGU="
+            },
+            "moment": {
+              "version": "2.10.6",
+              "resolved": "https://registry.npmjs.org/moment/-/moment-2.10.6.tgz",
+              "integrity": "sha1-bLIZZ8ecunsMpeZmRPFzZis++nc="
+            }
+          }
+        },
+        "kilt": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/kilt/-/kilt-2.0.0.tgz",
+          "integrity": "sha1-igb2YkoUhHRBwQLDsS6e8Gr13fI=",
+          "requires": {
+            "hoek": "3.0.0"
+          }
+        },
+        "mimos": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/mimos/-/mimos-3.0.0.tgz",
+          "integrity": "sha1-SygG4SXbvfcdmyzZ8LO0VsQDyCE=",
+          "requires": {
+            "hoek": "3.0.0",
+            "mime-db": "1.19.0"
+          },
+          "dependencies": {
+            "mime-db": {
+              "version": "1.19.0",
+              "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.19.0.tgz",
+              "integrity": "sha1-SWoYGYp86CRFNOJbsQK3T7Qg/VY="
+            }
+          }
+        },
+        "peekaboo": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/peekaboo/-/peekaboo-2.0.0.tgz",
+          "integrity": "sha1-ilS71o7esMtbMUSZHhU10tSS3Jc="
+        },
+        "qs": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-6.0.0.tgz",
+          "integrity": "sha1-3pnAxYxU6uSf/5SVEGcjOGkREOg="
+        },
+        "shot": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/shot/-/shot-2.0.1.tgz",
+          "integrity": "sha1-pEpYcr/KTSr60NVz1eIZWLtNwA8=",
+          "requires": {
+            "hoek": "3.0.0"
+          }
+        },
+        "statehood": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/statehood/-/statehood-3.0.0.tgz",
+          "integrity": "sha1-pJDgpzmG/ZlCFeT7xBSVwq6+BdM=",
+          "requires": {
+            "boom": "3.0.0",
+            "cryptiles": "3.0.0",
+            "hoek": "3.0.0",
+            "iron": "3.0.1",
+            "items": "2.0.0",
+            "joi": "7.0.0"
+          }
+        },
+        "subtext": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/subtext/-/subtext-3.0.1.tgz",
+          "integrity": "sha1-iBdgaPuBYqF2QyYzlHCWS9vhN8M=",
+          "requires": {
+            "boom": "3.0.0",
+            "content": "3.0.0",
+            "hoek": "3.0.0",
+            "pez": "2.0.1",
+            "qs": "6.0.0",
+            "wreck": "7.0.0"
+          },
+          "dependencies": {
+            "content": {
+              "version": "3.0.0",
+              "resolved": "https://registry.npmjs.org/content/-/content-3.0.0.tgz",
+              "integrity": "sha1-+xpmghRxLKPdGKTsuw9f5x+35s0=",
+              "requires": {
+                "boom": "3.0.0"
+              }
+            },
+            "pez": {
+              "version": "2.0.1",
+              "resolved": "https://registry.npmjs.org/pez/-/pez-2.0.1.tgz",
+              "integrity": "sha1-WAV4vrF/GU03y4dN+8aHzM3omxE=",
+              "requires": {
+                "b64": "3.0.0",
+                "boom": "3.0.0",
+                "content": "3.0.0",
+                "hoek": "3.0.0",
+                "nigel": "2.0.0"
+              },
+              "dependencies": {
+                "b64": {
+                  "version": "3.0.0",
+                  "resolved": "https://registry.npmjs.org/b64/-/b64-3.0.0.tgz",
+                  "integrity": "sha1-MrMhzdoLmzEMdi05OrqSAdjk8hc=",
+                  "requires": {
+                    "hoek": "3.0.0"
+                  }
+                },
+                "nigel": {
+                  "version": "2.0.0",
+                  "resolved": "https://registry.npmjs.org/nigel/-/nigel-2.0.0.tgz",
+                  "integrity": "sha1-4lEYegUz6ufIIy99ejhlrkdorWk=",
+                  "requires": {
+                    "hoek": "3.0.0",
+                    "vise": "2.0.0"
+                  },
+                  "dependencies": {
+                    "vise": {
+                      "version": "2.0.0",
+                      "resolved": "https://registry.npmjs.org/vise/-/vise-2.0.0.tgz",
+                      "integrity": "sha1-eNaLZOdJXqWYqcJMby4GLk1XldY=",
+                      "requires": {
+                        "hoek": "3.0.0"
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "wreck": {
+              "version": "7.0.0",
+              "resolved": "https://registry.npmjs.org/wreck/-/wreck-7.0.0.tgz",
+              "integrity": "sha1-jtUr2MIN4dApRr2QeP3LPEh6Gho=",
+              "requires": {
+                "boom": "3.0.0",
+                "hoek": "3.0.0"
+              }
+            }
+          }
+        },
+        "topo": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/topo/-/topo-2.0.0.tgz",
+          "integrity": "sha1-MVya7bhoytW2FhWWPJ/Qm+kSwe0=",
+          "requires": {
+            "hoek": "3.0.0"
+          }
+        }
+      }
+    },
+    "has-binary": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/has-binary/-/has-binary-0.1.7.tgz",
+      "integrity": "sha1-aOYesWIQyVRaClzOBqhzkS/h5ow=",
+      "requires": {
+        "isarray": "0.0.1"
+      }
+    },
+    "has-cors": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-cors/-/has-cors-1.1.0.tgz",
+      "integrity": "sha1-XkdHk/fqmEPRu5nCPu9J/xJv/zk="
+    },
+    "he": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/he/-/he-1.1.1.tgz",
+      "integrity": "sha1-k0EP0hsAlzUVH4howvJx80J+I/0="
+    },
+    "hoek": {
+      "version": "0.4.5",
+      "resolved": "https://registry.npmjs.org/hoek/-/hoek-0.4.5.tgz",
+      "integrity": "sha1-74qVM+gDueQtk7Hh5sqF/4MNk6E="
+    },
+    "html-minifier": {
+      "version": "3.5.16",
+      "resolved": "https://registry.npmjs.org/html-minifier/-/html-minifier-3.5.16.tgz",
+      "integrity": "sha512-zP5EfLSpiLRp0aAgud4CQXPQZm9kXwWjR/cF0PfdOj+jjWnOaCgeZcll4kYXSvIBPeUMmyaSc7mM4IDtA+kboA==",
+      "requires": {
+        "camel-case": "3.0.0",
+        "clean-css": "4.1.11",
+        "commander": "2.15.1",
+        "he": "1.1.1",
+        "param-case": "2.1.1",
+        "relateurl": "0.2.7",
+        "uglify-js": "3.3.26"
+      },
+      "dependencies": {
+        "clean-css": {
+          "version": "4.1.11",
+          "resolved": "https://registry.npmjs.org/clean-css/-/clean-css-4.1.11.tgz",
+          "integrity": "sha1-Ls3xRaujj1R0DybO/Q/z4D4SXWo=",
+          "requires": {
+            "source-map": "0.5.7"
+          }
+        },
+        "commander": {
+          "version": "2.15.1",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.15.1.tgz",
+          "integrity": "sha512-VlfT9F3V0v+jr4yxPc5gg9s62/fIVWsd2Bk2iD435um1NlGMYdVCq+MjcXnhYq2icNOizHr1kK+5TI6H0Hy0ag=="
+        },
+        "source-map": {
+          "version": "0.5.7",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
+        }
+      }
+    },
+    "http-errors": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.3.1.tgz",
+      "integrity": "sha1-GX4izevUGYWF6GlO9nhhl7ke2UI=",
+      "requires": {
+        "inherits": "2.0.3",
+        "statuses": "1.2.1"
+      }
+    },
+    "indexof": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/indexof/-/indexof-0.0.1.tgz",
+      "integrity": "sha1-gtwzbSMrkGIXnQWrMpOmYFn9Q10="
+    },
+    "inflection": {
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/inflection/-/inflection-1.12.0.tgz",
+      "integrity": "sha1-ogCTVlbW9fa8TcdQLhrstwMihBY="
+    },
+    "inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+      "requires": {
+        "once": "1.4.0",
+        "wrappy": "1.0.2"
+      }
+    },
+    "inherits": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
+    },
+    "ipaddr.js": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.0.5.tgz",
+      "integrity": "sha1-X6eM8wG4JceKvDBC2BJyMEnqI8c="
+    },
+    "isarray": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+      "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
+    },
+    "ischanged": {
+      "version": "1.0.18",
+      "resolved": "https://registry.npmjs.org/ischanged/-/ischanged-1.0.18.tgz",
+      "integrity": "sha1-IFZ/pssBgcVrme2zz8GMrbGWYcQ=",
+      "requires": {
+        "checkup": "1.3.0",
+        "debug": "2.6.9",
+        "mkdirp": "0.5.1",
+        "readjson": "1.1.4",
+        "timem": "1.1.2",
+        "writejson": "1.1.2"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+        }
+      }
+    },
+    "itype": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/itype/-/itype-2.0.3.tgz",
+      "integrity": "sha1-tJeJFmGF7dz8jTBmkRAsW34tJ6k="
+    },
+    "join-io": {
+      "version": "1.4.6",
+      "resolved": "https://registry.npmjs.org/join-io/-/join-io-1.4.6.tgz",
+      "integrity": "sha1-8yF74hMAeEsEaTqXyxeDtvnbW+w=",
+      "requires": {
+        "currify": "2.0.6",
+        "execon": "1.2.9",
+        "files-io": "1.2.8",
+        "minify": "2.1.8",
+        "ponse": "1.6.1"
+      }
+    },
+    "jquery": {
+      "version": "3.0.0-beta1",
+      "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.0.0-beta1.tgz",
+      "integrity": "sha1-0qTjaOLu1wUL9mq7u1TbLqNFNJ0="
+    },
+    "json3": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/json3/-/json3-3.2.6.tgz",
+      "integrity": "sha1-9u/JPAagTemuxTBT3yVZuxniA4s="
+    },
+    "lodash": {
+      "version": "4.12.0",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.12.0.tgz",
+      "integrity": "sha1-K9bcRqBA9Z5obJcu0h2T3FkFMlg="
+    },
+    "lower-case": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/lower-case/-/lower-case-1.1.4.tgz",
+      "integrity": "sha1-miyr0bno4K6ZOkv31YdcOcQujqw="
+    },
+    "media-typer": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
+      "integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g="
+    },
+    "merge-descriptors": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
+      "integrity": "sha1-sAqqVW3YtEVoFQ7J0blT8/kMu2E="
+    },
+    "methods": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
+      "integrity": "sha1-VSmk1nZUE07cxSZmVoNbD4Ua/O4="
+    },
+    "mime": {
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-1.3.4.tgz",
+      "integrity": "sha1-EV+eO2s9rylZmDyzjxSaLUDrXVM="
+    },
+    "mime-db": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.33.0.tgz",
+      "integrity": "sha512-BHJ/EKruNIqJf/QahvxwQZXKygOQ256myeN/Ew+THcAa5q+PjyTTMMeNQC4DZw5AwfvelsUrA6B67NKMqXDbzQ=="
+    },
+    "mime-types": {
+      "version": "2.1.18",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.18.tgz",
+      "integrity": "sha512-lc/aahn+t4/SWV/qcmumYjymLsWfN3ELhpmVuUFjgsORruuZPVSwAQryq+HHGvO/SI2KVX26bx+En+zhM8g8hQ==",
+      "requires": {
+        "mime-db": "1.33.0"
+      }
+    },
+    "minify": {
+      "version": "2.1.8",
+      "resolved": "https://registry.npmjs.org/minify/-/minify-2.1.8.tgz",
+      "integrity": "sha512-I+Gp6NZZdJjaxawv2nX6tSt90owL0216dXLjf6GOpWzQzwaENKQXuhQeFYzw8qDmQ3dIf1T5tvL/pinTqrPBqw==",
+      "requires": {
+        "clean-css": "3.4.28",
+        "css-b64-images": "0.2.5",
+        "debug": "2.6.9",
+        "execon": "1.2.9",
+        "html-minifier": "3.5.16",
+        "tomas": "1.0.2",
+        "try-catch": "1.0.0",
+        "uglify-js": "3.3.26"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+        }
+      }
+    },
+    "minimatch": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "requires": {
+        "brace-expansion": "1.1.11"
+      }
+    },
+    "minimist": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+      "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
+    },
+    "mkdirp": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+      "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+      "requires": {
+        "minimist": "0.0.8"
+      }
+    },
+    "mollify": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/mollify/-/mollify-1.0.8.tgz",
+      "integrity": "sha1-LSWLQkNfj+0ZkSeTDCs3JChmrQQ=",
+      "requires": {
+        "minify": "2.1.8",
+        "ponse": "1.6.1"
+      }
+    },
+    "moment": {
+      "version": "2.22.1",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.22.1.tgz",
+      "integrity": "sha512-shJkRTSebXvsVqk56I+lkb2latjBs8I+pc2TzWc545y2iFnSjm7Wg0QMh+ZWcdSLQyGEau5jI8ocnmkyTgr9YQ=="
+    },
+    "moment-timezone": {
+      "version": "0.5.17",
+      "resolved": "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.5.17.tgz",
+      "integrity": "sha512-Y/JpVEWIOA9Gho4vO15MTnW1FCmHi3ypprrkUaxsZ1TKg3uqC8q/qMBjTddkHoiwwZN3qvZSr4zJP7x9V3LpXA==",
+      "requires": {
+        "moment": "2.22.1"
+      }
+    },
+    "ms": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
+      "integrity": "sha1-nNE8A62/8ltl7/3nzoZO6VIBcJg="
+    },
+    "negotiator": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.5.3.tgz",
+      "integrity": "sha1-Jp1cR2gQ7JLtvntsLygxY4T5p+g="
+    },
+    "no-case": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/no-case/-/no-case-2.3.2.tgz",
+      "integrity": "sha512-rmTZ9kz+f3rCvK2TD1Ue/oZlns7OGoIWP4fc3llxxRXlOkHKoWPPWJOfFYpITabSow43QJbRIoHQXtt10VldyQ==",
+      "requires": {
+        "lower-case": "1.1.4"
+      }
+    },
+    "node-uuid": {
+      "version": "1.4.8",
+      "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.8.tgz",
+      "integrity": "sha1-sEDrCSOWivq/jTL7HxfxFn/auQc="
+    },
+    "object-component": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/object-component/-/object-component-0.0.3.tgz",
+      "integrity": "sha1-8MaapQ78lbhmwYb0AKM3acsvEpE="
+    },
+    "on-finished": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
+      "integrity": "sha1-IPEzZIGwg811M3mSoWlxqi2QaUc=",
+      "requires": {
+        "ee-first": "1.1.1"
+      }
+    },
+    "once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "requires": {
+        "wrappy": "1.0.2"
+      }
+    },
+    "options": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/options/-/options-0.0.6.tgz",
+      "integrity": "sha1-7CLTEoBrtT5zF3Pnza788cZDEo8="
+    },
+    "os-homedir": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
+      "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M="
+    },
+    "param-case": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/param-case/-/param-case-2.1.1.tgz",
+      "integrity": "sha1-35T9jPZTHs915r75oIWPvHK+Ikc=",
+      "requires": {
+        "no-case": "2.3.2"
+      }
+    },
+    "parsejson": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/parsejson/-/parsejson-0.0.1.tgz",
+      "integrity": "sha1-mxDGwNglq1ieaFFTgm3go7oni8w=",
+      "requires": {
+        "better-assert": "1.0.2"
+      }
+    },
+    "parseqs": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/parseqs/-/parseqs-0.0.2.tgz",
+      "integrity": "sha1-nf5wss3aw4i95PNbHyQPpYrb5sc=",
+      "requires": {
+        "better-assert": "1.0.2"
+      }
+    },
+    "parseuri": {
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/parseuri/-/parseuri-0.0.4.tgz",
+      "integrity": "sha1-gGWCo5iH4eoY3V4v4OAZAiaOk1A=",
+      "requires": {
+        "better-assert": "1.0.2"
+      }
+    },
+    "parseurl": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.2.tgz",
+      "integrity": "sha1-/CidTtiZMRlGDBViUyYs3I3mW/M="
+    },
+    "path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
+    },
+    "path-to-regexp": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
+      "integrity": "sha1-32BBeABfUi8V60SQ5yR6G/qmf4w="
+    },
+    "pipe-io": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/pipe-io/-/pipe-io-2.0.5.tgz",
+      "integrity": "sha512-Jlg0RpwKHsfAIlCYru38HjEiDnzfQUVHfU9A7Tc32qeeh0idnmbE+pJuv15Uo7AzeGJQLQZGb6x0bB70Zcbt7Q=="
+    },
+    "ponse": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/ponse/-/ponse-1.6.1.tgz",
+      "integrity": "sha512-govtuvVbXkfqXq3tZqfNAfSxaDMu279DZp2lKMBNdl3mRgUYRVV0I70JkhUmoWJacqmXVSA7VtW73U9EPxSruA==",
+      "requires": {
+        "debug": "3.1.0",
+        "execon": "1.2.9",
+        "extendy": "1.0.1",
+        "files-io": "1.2.8",
+        "itype": "2.0.3"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+        }
+      }
+    },
+    "proxy-addr": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-1.0.10.tgz",
+      "integrity": "sha1-DUCoL4Afw1VWfS7LZe/j8HfxIcU=",
+      "requires": {
+        "forwarded": "0.1.2",
+        "ipaddr.js": "1.0.5"
+      }
+    },
+    "pullout": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/pullout/-/pullout-1.0.2.tgz",
+      "integrity": "sha1-U0Xqn7rVbbxQTdsgT5InAHtn0eM="
+    },
+    "qs": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-4.0.0.tgz",
+      "integrity": "sha1-wx2bdOwn33XlQ6hseHKO2NRiNgc="
+    },
+    "range-parser": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.0.3.tgz",
+      "integrity": "sha1-aHKCNTXGkuLCoBA4Jq/YLC4P8XU="
+    },
+    "readjson": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/readjson/-/readjson-1.1.4.tgz",
+      "integrity": "sha512-H4dRk2S67w3HtE1apnw5wlHpN9qkJ0pen0AcEvyAfnrPfskZIyUOYLXpfN6olDQZI+eUlxg0Yo4lJ2bymujOUA==",
+      "requires": {
+        "try-catch": "2.0.0"
+      },
+      "dependencies": {
+        "try-catch": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/try-catch/-/try-catch-2.0.0.tgz",
+          "integrity": "sha512-RPXpVjsbtWgymwGq5F/OWDFsjEzdvzwHFaMjWWW6f/p6+uk/N7YSKJHQfIfGqITfj8qH4cBqCLMnhKZBaKk7Kg=="
+        }
+      }
+    },
+    "relateurl": {
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/relateurl/-/relateurl-0.2.7.tgz",
+      "integrity": "sha1-VNvzd+UUQKypCkzSdGANP/LYiKk="
+    },
+    "rendy": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/rendy/-/rendy-1.1.1.tgz",
+      "integrity": "sha512-NoT4MGWLdwuvsH0pEMzoaZrRHQHUYehLOPyF4I6w4B4kMpt9UvALkJGRUEubKFoa/hJjpCyr1XJ/LhoA/g8ocQ=="
+    },
+    "retry-as-promised": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/retry-as-promised/-/retry-as-promised-2.3.2.tgz",
+      "integrity": "sha1-zZdO5P2bX+A8vzGHHuSCIcB3N7c=",
+      "requires": {
+        "bluebird": "3.5.1",
+        "debug": "2.6.9"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+        }
+      }
+    },
+    "semver": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz",
+      "integrity": "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA=="
+    },
+    "send": {
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/send/-/send-0.13.1.tgz",
+      "integrity": "sha1-ow1fTILIqbrprQCh2bG9vm8Zntc=",
+      "requires": {
+        "debug": "2.2.0",
+        "depd": "1.1.2",
+        "destroy": "1.0.4",
+        "escape-html": "1.0.3",
+        "etag": "1.7.0",
+        "fresh": "0.3.0",
+        "http-errors": "1.3.1",
+        "mime": "1.3.4",
+        "ms": "0.7.1",
+        "on-finished": "2.3.0",
+        "range-parser": "1.0.3",
+        "statuses": "1.2.1"
+      }
+    },
+    "sequelize": {
+      "version": "3.24.0",
+      "resolved": "https://registry.npmjs.org/sequelize/-/sequelize-3.24.0.tgz",
+      "integrity": "sha1-p3P+Y9ZA6w7pSJukvACoEdibFXo=",
+      "requires": {
+        "bluebird": "3.5.1",
+        "depd": "1.1.2",
+        "dottie": "1.1.1",
+        "generic-pool": "2.4.2",
+        "inflection": "1.12.0",
+        "lodash": "4.12.0",
+        "moment": "2.22.1",
+        "moment-timezone": "0.5.17",
+        "node-uuid": "1.4.8",
+        "retry-as-promised": "2.3.2",
+        "semver": "5.5.0",
+        "shimmer": "1.1.0",
+        "terraformer-wkt-parser": "1.2.0",
+        "toposort-class": "1.0.1",
+        "validator": "5.7.0",
+        "wkx": "0.2.0"
+      }
+    },
+    "serve-static": {
+      "version": "1.10.3",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.10.3.tgz",
+      "integrity": "sha1-zlpuzTEB/tXsCYJ9rCKpwpv7BTU=",
+      "requires": {
+        "escape-html": "1.0.3",
+        "parseurl": "1.3.2",
+        "send": "0.13.2"
+      },
+      "dependencies": {
+        "send": {
+          "version": "0.13.2",
+          "resolved": "https://registry.npmjs.org/send/-/send-0.13.2.tgz",
+          "integrity": "sha1-dl52B8gFVFK7pvCwUllTUJhgNt4=",
+          "requires": {
+            "debug": "2.2.0",
+            "depd": "1.1.2",
+            "destroy": "1.0.4",
+            "escape-html": "1.0.3",
+            "etag": "1.7.0",
+            "fresh": "0.3.0",
+            "http-errors": "1.3.1",
+            "mime": "1.3.4",
+            "ms": "0.7.1",
+            "on-finished": "2.3.0",
+            "range-parser": "1.0.3",
+            "statuses": "1.2.1"
+          }
+        }
+      }
+    },
+    "shimmer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/shimmer/-/shimmer-1.1.0.tgz",
+      "integrity": "sha1-l9c3cTf/u6tCVSLkKf4KqJpIizU="
+    },
+    "socket.io": {
+      "version": "1.4.8",
+      "resolved": "https://registry.npmjs.org/socket.io/-/socket.io-1.4.8.tgz",
+      "integrity": "sha1-5XbzMM0L7WTlWz/SbfmRFBiEhns=",
+      "requires": {
+        "debug": "2.2.0",
+        "engine.io": "1.6.11",
+        "has-binary": "0.1.7",
+        "socket.io-adapter": "0.4.0",
+        "socket.io-client": "1.4.8",
+        "socket.io-parser": "2.2.6"
+      }
+    },
+    "socket.io-adapter": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/socket.io-adapter/-/socket.io-adapter-0.4.0.tgz",
+      "integrity": "sha1-+5+CqxqmUpC/csNleVW5MKmRok8=",
+      "requires": {
+        "debug": "2.2.0",
+        "socket.io-parser": "2.2.2"
+      },
+      "dependencies": {
+        "socket.io-parser": {
+          "version": "2.2.2",
+          "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-2.2.2.tgz",
+          "integrity": "sha1-PXr2tkSX6Va32f53X5mXFgJ/lBc=",
+          "requires": {
+            "benchmark": "1.0.0",
+            "component-emitter": "1.1.2",
+            "debug": "0.7.4",
+            "isarray": "0.0.1",
+            "json3": "3.2.6"
+          },
+          "dependencies": {
+            "debug": {
+              "version": "0.7.4",
+              "resolved": "https://registry.npmjs.org/debug/-/debug-0.7.4.tgz",
+              "integrity": "sha1-BuHqgILCyxTjmAbiLi9vdX+Srzk="
+            }
+          }
+        }
+      }
+    },
+    "socket.io-client": {
+      "version": "1.4.8",
+      "resolved": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-1.4.8.tgz",
+      "integrity": "sha1-SBskHnPfFA6hpPsDSGqFrQl/VVg=",
+      "requires": {
+        "backo2": "1.0.2",
+        "component-bind": "1.0.0",
+        "component-emitter": "1.2.0",
+        "debug": "2.2.0",
+        "engine.io-client": "1.6.11",
+        "has-binary": "0.1.7",
+        "indexof": "0.0.1",
+        "object-component": "0.0.3",
+        "parseuri": "0.0.4",
+        "socket.io-parser": "2.2.6",
+        "to-array": "0.1.4"
+      },
+      "dependencies": {
+        "component-emitter": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.2.0.tgz",
+          "integrity": "sha1-zNETqGOI0GSC0D3j/H35hSa6jv4="
+        }
+      }
+    },
+    "socket.io-parser": {
+      "version": "2.2.6",
+      "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-2.2.6.tgz",
+      "integrity": "sha1-ON/WHfUNz4qx2eIJEyK/kCuii5k=",
+      "requires": {
+        "benchmark": "1.0.0",
+        "component-emitter": "1.1.2",
+        "debug": "2.2.0",
+        "isarray": "0.0.1",
+        "json3": "3.3.2"
+      },
+      "dependencies": {
+        "json3": {
+          "version": "3.3.2",
+          "resolved": "https://registry.npmjs.org/json3/-/json3-3.3.2.tgz",
+          "integrity": "sha1-PAQ0dD35Pi9cQq7nsZvLSDV19OE="
+        }
+      }
+    },
+    "source-map": {
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
+      "integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
+      "requires": {
+        "amdefine": "1.0.1"
+      }
+    },
+    "spawnify": {
+      "version": "2.3.4",
+      "resolved": "https://registry.npmjs.org/spawnify/-/spawnify-2.3.4.tgz",
+      "integrity": "sha1-1n7P05m9r7Bm6esuM5hsF+BtFIo=",
+      "requires": {
+        "glob": "7.1.2",
+        "tildify": "1.2.0",
+        "try-catch": "1.0.0",
+        "untildify": "2.1.0",
+        "win32": "0.9.12"
+      },
+      "dependencies": {
+        "tildify": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/tildify/-/tildify-1.2.0.tgz",
+          "integrity": "sha1-3OwD9V3Km3qj5bBPIYF+tW5jWIo=",
+          "requires": {
+            "os-homedir": "1.0.2"
+          }
+        }
+      }
+    },
+    "statuses": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.2.1.tgz",
+      "integrity": "sha1-3e1FzBglbVHtQK7BQkidXGECbSg="
+    },
+    "terraformer": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/terraformer/-/terraformer-1.0.8.tgz",
+      "integrity": "sha1-UeCtiXRvzyFh3G9lqnDkI3fItZM=",
+      "requires": {
+        "@types/geojson": "1.0.6"
+      }
+    },
+    "terraformer-wkt-parser": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/terraformer-wkt-parser/-/terraformer-wkt-parser-1.2.0.tgz",
+      "integrity": "sha512-QU3iA54St5lF8Za1jg1oj4NYc8sn5tCZ08aNSWDeGzrsaV48eZk1iAVWasxhNspYBoCqdHuoot1pUTUrE1AJ4w==",
+      "requires": {
+        "@types/geojson": "1.0.6",
+        "terraformer": "1.0.8"
+      }
+    },
+    "tildify": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/tildify/-/tildify-1.1.2.tgz",
+      "integrity": "sha1-n2Edii6TpeUHVtsEDxzSt/2AhZ0=",
+      "requires": {
+        "os-homedir": "1.0.2"
+      }
+    },
+    "timem": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/timem/-/timem-1.1.2.tgz",
+      "integrity": "sha1-/pMAbCglOo2lxJKZMGmR+kzE9Aw="
+    },
+    "tinymce": {
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/tinymce/-/tinymce-4.2.4.tgz",
+      "integrity": "sha1-ScrPb5VqpLVL4e7CGOQVXAgX/ug="
+    },
+    "to-array": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/to-array/-/to-array-0.1.4.tgz",
+      "integrity": "sha1-F+bBH3PdTz10zaek/zI46a2b+JA="
+    },
+    "tomas": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/tomas/-/tomas-1.0.2.tgz",
+      "integrity": "sha1-0eR/zBfmFpd7hZ7x/+SXu53Tz2k=",
+      "requires": {
+        "checkup": "1.3.0",
+        "execon": "1.2.9",
+        "ischanged": "1.0.18",
+        "mkdirp": "0.5.1"
+      }
+    },
+    "toposort-class": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/toposort-class/-/toposort-class-1.0.1.tgz",
+      "integrity": "sha1-f/0feMi+KMO6Rc1OGj9e4ZO9mYg="
+    },
+    "try-catch": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/try-catch/-/try-catch-1.0.0.tgz",
+      "integrity": "sha1-N5fas5omZ3X00Npcv0Kso/A2COY="
+    },
+    "type-is": {
+      "version": "1.6.16",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.16.tgz",
+      "integrity": "sha512-HRkVv/5qY2G6I8iab9cI7v1bOIdhm94dVjQCPFElW9W+3GeDOSHmy2EBYe4VTApuzolPcmgFTN3ftVJRKR2J9Q==",
+      "requires": {
+        "media-typer": "0.3.0",
+        "mime-types": "2.1.18"
+      }
+    },
+    "uglify-js": {
+      "version": "3.3.26",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.3.26.tgz",
+      "integrity": "sha512-XHxutZNxbx0UnqNUrjL/wvABLxirEYpbAnjCWGakPfQRJbbAGF2dI+YYw300F5mYKm7zBtgYiw3kOiQFobzglQ==",
+      "requires": {
+        "commander": "2.15.1",
+        "source-map": "0.6.1"
+      },
+      "dependencies": {
+        "commander": {
+          "version": "2.15.1",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.15.1.tgz",
+          "integrity": "sha512-VlfT9F3V0v+jr4yxPc5gg9s62/fIVWsd2Bk2iD435um1NlGMYdVCq+MjcXnhYq2icNOizHr1kK+5TI6H0Hy0ag=="
+        },
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
+        }
+      }
+    },
+    "ultron": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/ultron/-/ultron-1.0.2.tgz",
+      "integrity": "sha1-rOEWq1V80Zc4ak6I9GhTeMiy5Po="
+    },
+    "unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw="
+    },
+    "untildify": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/untildify/-/untildify-2.1.0.tgz",
+      "integrity": "sha1-F+soB5h/dpUunASF/DEdBqgmouA=",
+      "requires": {
+        "os-homedir": "1.0.2"
+      }
+    },
+    "upper-case": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/upper-case/-/upper-case-1.1.3.tgz",
+      "integrity": "sha1-9rRQHC7EzdJrp4vnIilh3ndiFZg="
+    },
+    "utf8": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/utf8/-/utf8-2.1.0.tgz",
+      "integrity": "sha1-DP7FyAUtRKI+OqqQgQToB1+V39U="
+    },
+    "utils-merge": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.0.tgz",
+      "integrity": "sha1-ApT7kiu5N1FTVBxPcJYjHyh8ivg="
+    },
+    "validator": {
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/validator/-/validator-5.7.0.tgz",
+      "integrity": "sha1-eoelgUa2laxIYHEUHAxJ1n2gXlw="
+    },
+    "vary": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.0.1.tgz",
+      "integrity": "sha1-meSYFWaihhGN+yuBc1ffeZM3bRA="
+    },
+    "win32": {
+      "version": "0.9.12",
+      "resolved": "https://registry.npmjs.org/win32/-/win32-0.9.12.tgz",
+      "integrity": "sha1-Pii1+Qje50uE4xPgf0x48ksRNgA=",
+      "requires": {
+        "pullout": "1.0.2"
+      }
+    },
+    "wkx": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/wkx/-/wkx-0.2.0.tgz",
+      "integrity": "sha1-dsJPFqzQzY+TzTSqMx4PeWElboQ="
+    },
+    "wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+    },
+    "writejson": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/writejson/-/writejson-1.1.2.tgz",
+      "integrity": "sha512-5iMR/5y0z7VUNI3S+wRWiu02VnbwuPzrwnUbopJA2sz1kWvSm6Phz/1ahbgQ76SO1HGB9d/RI+44rEcBFtZbMw==",
+      "requires": {
+        "try-catch": "2.0.0"
+      },
+      "dependencies": {
+        "try-catch": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/try-catch/-/try-catch-2.0.0.tgz",
+          "integrity": "sha512-RPXpVjsbtWgymwGq5F/OWDFsjEzdvzwHFaMjWWW6f/p6+uk/N7YSKJHQfIfGqITfj8qH4cBqCLMnhKZBaKk7Kg=="
+        }
+      }
+    },
+    "ws": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-1.1.0.tgz",
+      "integrity": "sha1-wdb9FRXTzv8fCuJ1m/X9dwMKrR0=",
+      "requires": {
+        "options": "0.0.6",
+        "ultron": "1.0.2"
+      }
+    },
+    "xmlhttprequest-ssl": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/xmlhttprequest-ssl/-/xmlhttprequest-ssl-1.5.1.tgz",
+      "integrity": "sha1-O3dB/qSoZnWXbpCNKW1ERZYfqmc="
+    },
+    "yeast": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/yeast/-/yeast-0.1.2.tgz",
+      "integrity": "sha1-AI4G2AlDIMNy28L47XagymyKxBk="
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -5,14 +5,14 @@
   "author": "srcclr <hello@srcclr.com>",
   "description": "A node project to demostrate srcclr scans",
   "dependencies": {
-    "jquery": "3.0.0-alpha1",
-    "express": "4.1.1",
-    "boom": "0.2.1",
-    "tinymce": "4.2.3",
-    "hapi": "8.1.0",
-    "sequelize": "3.12.1",
-    "console-io": "2.6.3",
+    "jquery": "3.0.0-beta1",
+    "express": "4.5.0",
+    "boom": "0.3.0",
+    "tinymce": "4.2.4",
+    "hapi": "11.1.4",
+    "sequelize": "3.24.0",
+    "console-io": "2.7.0",
     "angular": "1.3.19",
-    "cookie-signature": "1.0.2"
+    "cookie-signature": "1.0.4"
   }
 }


### PR DESCRIPTION
SourceClear generated this pull request to update the following vulnerable libraries.

| Type | Library | From | To |
| --- | --- | --- | --- |
| NPM | `sequelize` | 3.12.1 | 3.24.0 |
| NPM | `express` | 4.1.1 | 4.5.0 |
| NPM | `tinymce` | 4.2.3 | 4.2.4 |
| NPM | `console-io` | 2.6.3 | 2.7.0 |
| NPM | `jquery` | 3.0.0-alpha1 | 3.0.0-beta1 |
| NPM | `hapi` | 8.1.0 | 11.1.4 |
| NPM | `boom` | 0.2.1 | 0.3.0 |
| NPM | `cookie-signature` | 1.0.2 | 1.0.4 |

<!-- srcclr-pr-id-6ab0d8b36db7b6499e44badf5df189dcdfa1268876bfe42e265285b5385d784c -->
